### PR TITLE
Prepare for NetBeans exec.vmArgs and exec.appArgs enhancement

### DIFF
--- a/micronautui-demo/nbactions.xml
+++ b/micronautui-demo/nbactions.xml
@@ -84,4 +84,28 @@
                 <activatedProfile>webkit-presenter</activatedProfile>
             </activatedProfiles>
         </action>
+        <action>
+            <actionName>run.single.main</actionName>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>exec:exec</goal>
+            </goals>
+            <activatedProfiles>
+                <activatedProfile>desktop</activatedProfile>
+            </activatedProfiles>
+        </action>
+        <action>
+            <actionName>debug.single.main</actionName>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>exec:exec</goal>
+            </goals>
+            <properties>
+                <jpda.listen>true</jpda.listen>
+                <exec.debug.arg>-Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address}</exec.debug.arg>
+            </properties>
+            <activatedProfiles>
+                <activatedProfile>desktop</activatedProfile>
+            </activatedProfiles>
+        </action>
 </actions>

--- a/micronautui-demo/pom.xml
+++ b/micronautui-demo/pom.xml
@@ -47,6 +47,8 @@
     <project.mainclass>io.micronaut.ui.demo.Main</project.mainclass>
     <exec.java.bin>${java.home}/bin/java</exec.java.bin>
     <exec.debug.arg></exec.debug.arg>
+    <exec.vmArgs></exec.vmArgs>
+    <exec.appArgs></exec.appArgs>
     <net.java.html.version>1.7</net.java.html.version>
     <openjfx.version>11</openjfx.version>
     <springloaded.javaagent></springloaded.javaagent>
@@ -88,7 +90,7 @@
                        -Xverify:none${springloaded.javaagent}
                        -Dbrowser.rootdir=${basedir}/src/main/webapp/
                        -Dnetbeans.inspect.port=${netbeans.inspect.port}
-                       ${exec.debug.arg} ${project.mainclass}
+                       ${exec.debug.arg} ${exec.vmArgs} ${project.mainclass} ${exec.appArgs}
                    </commandlineArgs>
                 </configuration>
           </plugin>

--- a/micronautui-demo/src/main/java/io/micronaut/ui/demo/Demo.java
+++ b/micronautui-demo/src/main/java/io/micronaut/ui/demo/Demo.java
@@ -49,7 +49,7 @@ public class Demo {
         this.client = client;
     }
 
-    private String desc = "Buy Milk";
+    private String desc;
     private List<Item> todos = Models.asList();
     private Show show = Show.ALL;
 
@@ -162,9 +162,10 @@ public class Demo {
         return getShow() == Show.DONE;
     }
 
-    public static void onPageLoad() {
+    public static void onPageLoad(String[] args) {
         ApplicationContext ac = ApplicationContext.run();
         Demo ui = ac.getBean(Demo.class);
+        ui.setDesc(args.length > 0 ? args[0] : "Buy Milk!");
         applyBindings(ui);
     }
 

--- a/micronautui-demo/src/main/java/io/micronaut/ui/demo/Main.java
+++ b/micronautui-demo/src/main/java/io/micronaut/ui/demo/Main.java
@@ -41,7 +41,7 @@ public final class Main {
         System.exit(0);
     }
 
-    public static void onPageLoad() throws Exception {
-        Demo.onPageLoad();
+    public static void onPageLoad(String[] args) throws Exception {
+        Demo.onPageLoad(args);
     }
 }


### PR DESCRIPTION
Getting ready for https://github.com/apache/netbeans/pull/2731 - specifying and using `exec.vmArgs` and `exec.jvmArgs`. Is this correct @sdedic?

How shall I use that from VSNetBeans? I can open the `micronautui-demo` project as a folder in Code. Then I can specify `launch.json` file like
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "java8+",
            "request": "launch",
            "name": "Launch Java 8+ App",
            "mainClass": "${file}",
            "args": "Pozdrav!"
        }
    ]
}
```
but the `main` method is always called without any arguments. What's the right way to pass arguments to the process? It seems that the `args` value is properly read in `NbLaunchDelegate` and an instance of `ExplicitProcessParameters` is put into the lookup. But it doesn't seem to be used....